### PR TITLE
refactor/sensor-pointers

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -29,10 +29,10 @@ int main(void) {
   printk("%s\n", APP_ASCII_BANNER);
   LOG_INF("===== Buzzverse Node System Booting (Zephyr Log) =====");
 
-  BME280 bme280(DEVICE_DT_GET_ANY(bosch_bme280));
+  BME280 bme280;
   Analog analog(&soil_sensor_adc_spec);
 
-  // Array of available sensors
+  // Array of supported sensors
   etl::array<etl::unique_ptr<Sensor>, NUMBER_OF_SENSORS> sensors {
 	etl::unique_ptr<BME280>(etl::move(&bme280)),
 #ifdef CONFIG_ENABLE_ANALOG
@@ -40,7 +40,7 @@ int main(void) {
 #endif
   };
 
-  BQ27441 bq27441(DEVICE_DT_GET_ANY(ti_bq274xx));
+  BQ27441 bq27441;
   LoRaWANHandler lorawan(bq27441);
 
   etl::unique_ptr<SleepManager> p_sleep_manager(nullptr);

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -29,14 +29,11 @@ int main(void) {
   printk("%s\n", APP_ASCII_BANNER);
   LOG_INF("===== Buzzverse Node System Booting (Zephyr Log) =====");
 
-  BME280 bme280;
-  Analog analog(&soil_sensor_adc_spec);
-
   // Array of supported sensors
   etl::array<etl::unique_ptr<Sensor>, NUMBER_OF_SENSORS> sensors {
-	etl::unique_ptr<BME280>(etl::move(&bme280)),
+	  etl::unique_ptr<BME280>(new BME280()),
 #ifdef CONFIG_ENABLE_ANALOG
-  etl::unique_ptr<Analog>(etl::move(&analog)),
+	etl::unique_ptr<Analog>(new Analog(&soil_sensor_adc_spec)),
 #endif
   };
 

--- a/app/src/sensors/bme280/bme280.cpp
+++ b/app/src/sensors/bme280/bme280.cpp
@@ -7,7 +7,7 @@
 
 LOG_MODULE_REGISTER(bme280, LOG_LEVEL_DBG);
 
-BME280::BME280(const device* dev) : bme280_dev(dev) {}
+BME280::BME280() : bme280_dev(DEVICE_DT_GET_ANY(bosch_bme280)) {}
 
 using Status = Sensor::Status;
 

--- a/app/src/sensors/bme280/bme280.hpp
+++ b/app/src/sensors/bme280/bme280.hpp
@@ -9,7 +9,7 @@
 
 class BME280 : public Sensor {
  public:
-  explicit BME280(const device* dev);
+  explicit BME280();
 
   Peripheral::Status init() override;
 
@@ -24,7 +24,6 @@ class BME280 : public Sensor {
   Status get_packet(buzzverse_v1_Packet& packet) const override;
 
   void get_status(buzzverse_v1_Status& status_message) const override;
-
  private:
   const device* bme280_dev;
   bool ready{false};

--- a/app/src/sensors/bq27441/bq27441.cpp
+++ b/app/src/sensors/bq27441/bq27441.cpp
@@ -7,7 +7,7 @@
 
 LOG_MODULE_REGISTER(bq27441, LOG_LEVEL_DBG);
 
-BQ27441::BQ27441(const device* dev) : bq27441_dev(dev) {}
+BQ27441::BQ27441() : bq27441_dev(DEVICE_DT_GET_ANY(ti_bq274xx)) {}
 
 using Status = Sensor::Status;
 

--- a/app/src/sensors/bq27441/bq27441.hpp
+++ b/app/src/sensors/bq27441/bq27441.hpp
@@ -9,7 +9,7 @@
 
 class BQ27441 : public Sensor {
  public:
-  explicit BQ27441(const device* dev);
+  explicit BQ27441();
 
   Peripheral::Status init() override;
 
@@ -24,7 +24,6 @@ class BQ27441 : public Sensor {
   Status get_packet(buzzverse_v1_Packet& packet) const override;
 
   void get_status(buzzverse_v1_Status& status_message) const override;
-
  private:
   const device* bq27441_dev;
   bool ready{false};


### PR DESCRIPTION
1) Sensor objects are now created as **unique_ptrs** that are passed into the Application constructor right from the start - instead of first creating static objects and then moving them inside the unique_ptrs. Code in main is thus simpler and easier to understand.
2) Zephyr device struct pointers obtained from DEVICE_DT_GET_ANY are now no longer parameters of the sensors' constructor. Instead, DEVICE_DT_GET_ANY is called **inside** the sensor class' constructor. This, again, makes main's code less cluttered. 
Note that this wasn't refactored in the Analog sensor, as the Analog sensor requires different specifications structs (obtained from ADC_DT_SPEC_GET) for different ADC sensors - that's why the soil sensor's specification wasn't hard-coded in the Analog constructor.
3) Internal device pointers in each Sensor class were kept as raw pointers, because DEVICE_DT_GET_ANY returns a device address from the device tree - no memory allocation is performed, so these pointers don't need to be deleted. Device pointers are not deleted in Zephyr samples, e. g. the BME280 sample.